### PR TITLE
adhere to padded-blocks

### DIFF
--- a/lib/rfc7239.js
+++ b/lib/rfc7239.js
@@ -5,7 +5,6 @@ module.exports = function (str) {
 
   str.split(/ *; */).forEach(function (element) {
     element.split(/ *, */).forEach(function (part) {
-
       var pair = part.split('=')
 
       var name = pair[0].toLowerCase()


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.
